### PR TITLE
Fix crash on 4.1+

### DIFF
--- a/res/layout/main.xml
+++ b/res/layout/main.xml
@@ -137,7 +137,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|center_horizontal"
         android:layout_marginBottom="35dip"
-        layout="@*android:layout/transient_notification"
+        layout="@layout/transient_notification"
         android:visibility="gone" />
 
 </FrameLayout>

--- a/res/layout/transient_notification.xml
+++ b/res/layout/transient_notification.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/* //device/apps/common/res/layout/transient_notification.xml
+**
+** Copyright 2006, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@android:id/message"
+        android:layout_width="wrap_content"
+        android:layout_height="0dip"
+        android:layout_weight="1"
+        android:layout_gravity="center_horizontal"
+        android:textAppearance="@android:style/TextAppearance.Small"
+        android:textColor="@android:color/background_light"
+        android:shadowColor="#BB000000"
+        android:shadowRadius="2.75"
+        />
+
+</LinearLayout>
+
+


### PR DESCRIPTION
Using private stuff from the Android SDK no longer works on 4.1+, so
import this and reference it.
